### PR TITLE
Affichage de la version de "Molise" sur TFT

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -226,7 +226,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Molise 2.0" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "Molise 2.3" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 /**
@@ -326,11 +326,11 @@
 
 // Name displayed in the LCD "Ready" message and Info menu
 #ifdef GENIUS
-    #define CUSTOM_MACHINE_NAME "Artillery Genius"
-  #endif
+  #define CUSTOM_MACHINE_NAME "Artillery Genius - " STRING_CONFIG_H_AUTHOR
+#endif
 #ifdef X1
-    #define CUSTOM_MACHINE_NAME "Artillery Sidewinder X1"
-  #endif
+  #define CUSTOM_MACHINE_NAME "Artillery Sidewinder X1 - " STRING_CONFIG_H_AUTHOR
+#endif
 
 // Printer's unique ID, used by some programs to differentiate between machines.
 // Choose your own or use a service like https://www.uuidgenerator.net/version4


### PR DESCRIPTION
### Description

Ajout du numéro de version "Molise" avec le nom de la machine pour que celle-ci soit visible dans le menu infos et le message défilant "ready"

### Requirements

Aucune modification du matériel ou autre déjà disponible.
Un flashage du firmware sera nécessaire.

### Benefits

Possibilité de voir le numéro de version  "Molise" du firmware qui a été flashé pour l'imprimante.

### Related Issues

Issue #91 