### PR TITLE
Provide PlatformIO build environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,33 @@ Others supported Options :
 - Mesh Validation Pattern (G26)
 - Etc ...
 
+#### How to build
+
+The simplest way to build is to switch the PlatformIO project environment and
+use one of the presets:
+
+- For the Sidewinder X1:
+  - **env:x1_mbl**: with Mesh Bed Leveling
+  - **env:x1_bltouch**: with BL Touch
+  - **env:x1_touchmi**: with Touch Mi
+- For the Genius:
+  - **env:genius_mbl**: with Mesh Bed Leveling
+  - **env:genius_bltouch**: with BL Touch
+  - **env:genius_touchmi**: with Touch Mi
+- For the Sidewinder X2: **env:x2**
+- For the Genius Pro: **env:geniuspro**
+- For the Hornet: **env:hornet**
+
+If you're using VSCode extension for PlatformIO, you should be able to pick the
+environment you want directly from the bottom bar. You can also build from `pio`
+command line directly, for instance:
+
+> pio run -e x1_mbl
+
+If you need more fined-grained configuration (e.g. custom board or custom
+extruder), you may stay on the default PlatformIO environment and follow through
+the instructions in [Marlin/Configuration.h](Marlin/Configuration.h).
+
 The code in the `Configuration.h` file has been split into 7 sections to make the code more readable. So, for people who want to compile code from source, the job will be easier. For more explanation on the code compilation, please refer to the [dedicated wiki](https://github.com/Dtcreation/Firmware-Molise-Artillery/wiki)
 
 Molise firmware is provided to you free of charge in an "as is" state. We cannot be held responsible for any damage it may do to your 3D printer if it occurs. Please proceed with caution.

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,10 +10,22 @@
 # Automatic targets - enable auto-uploading
 #targets = upload
 
+[env:default]
+# Set your board name here if you do not use an environment preset.
+extends          = env:change_value
+# Examples:
+# extends          = env:mega2560
+# extends          = env:Artillery_Ruby
+# extends          = env:LPC1768
+# extends          = env:LPC1769
+# extends          = env:BIGTREE_SKR_2
+# extends          = env:BIGTREE_SKR_2_F429
+# extends          = env:mks_robin_nano_v3_usb_flash_drive_msc
+
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = CHANGE_VALUE
+default_envs = default
 include_dir  = Marlin
 extra_configs =
     Marlin/config.ini
@@ -284,3 +296,56 @@ platform         = atmelavr
 board            = megaatmega2560
 build_flags      = -c -H -std=gnu++11 -Wall -Os -D__MARLIN_FIRMWARE__
 build_src_filter = +<src/MarlinCore.cpp>
+
+[swd_x1]
+extends          = env:mega2560
+build_flags      = ${env:mega2560.build_flags} -DX1 -DMKSGENL -DTITAN -DTMC_2100
+
+[env:x1_mbl]
+extends          = swd_x1
+build_flags      = ${swd_x1.build_flags} -DMESH_BED_LEVELING
+
+[env:x1_bltouch]
+extends          = swd_x1
+build_flags      = ${swd_x1.build_flags} -DBLTOUCH
+
+[env:x1_touchmi]
+extends          = swd_x1
+build_flags      = ${swd_x1.build_flags} -DTOUCH_MI_PROBE -DMKSGENL_TFT
+
+[swd_x2]
+extends          = env:Artillery_Ruby
+build_flags      = ${env:Artillery_Ruby.build_flags} -DSWD_X2 -DRUBY -DTITAN -DTMC_2100
+
+[env:x2]
+extends          = swd_x2
+
+[swd_genius]
+extends          = env:mega2560
+build_flags      = ${env:mega2560.build_flags} -DGENIUS -DMKSGENL -DTITAN -DTMC_2100
+
+[env:genius_mbl]
+extends          = swd_genius
+build_flags      = ${swd_genius.build_flags} -DMESH_BED_LEVELING
+
+[env:genius_bltouch]
+extends          = swd_genius
+build_flags      = ${swd_genius.build_flags} -DBLTOUCH
+
+[env:genius_touchmi]
+extends          = swd_genius
+build_flags      = ${swd_genius.build_flags} -DTOUCH_MI_PROBE -DMKSGENL_TFT
+
+[swd_geniuspro]
+extends          = env:Artillery_Ruby
+build_flags      = ${env:Artillery_Ruby.build_flags} -DGENIUSPRO -DRUBY -DTITAN -DTMC_2100
+
+[env:geniuspro]
+extends          = swd_geniuspro
+
+[swd_hornet]
+extends          = env:Artillery_Ruby
+build_flags      = ${env:Artillery_Ruby.build_flags} -DHORNET -DRUBY -DTITAN -DTMC_2100
+
+[env:hornet]
+extends          = swd_hornet


### PR DESCRIPTION
Je me suis aperçu qu'il manquait les firmwares TouchMi pour la X1 et la Genius dans la dernière release [4.0](https://github.com/Dtcreation/Firmware-Molise-Artillery/releases/tag/4.0). En même temps, le processus de release qui consiste à éditer à la main le fichier `Configuration.h` pour chaque configuration m'a semblé particulièrement fastidieux et propice aux erreurs et oublis. Cette PR propose de l'améliorer en fournissant des environnements PlatformIO permettant de construire automatiquement tous les firmwares sensés être inclus dans une release GitHub de Molise.

Je n'ai pas ajouté de job de CI dans GitHub Actions parce qu'il n'y en avait déjà pas. Néanmoins, si le besoin se présente, c'est possible de le faire dans une autre PR dédiée. Ce job pourrait même ajouter automatiquement les assets à la release GitHub.

À noter qu'il est toujours possible de modifier manuellement `Configuration.h` et le board, comme c'était le cas avant. Ce sont juste des nouveaux environnements qui sont là pour automatiser la construction dans les cas principaux. Ainsi, on peut juste construire tous les firmwares d'une release avec cette simple commande :

```
pio run \
  -e x1_mbl \
  -e x1_bltouch \
  -e x1_touchmi \
  -e x2 \
  -e genius_mbl \
  -e genius_bltouch \
  -e genius_touchmi \
  -e geniuspro \
  -e hornet
```

Ça devrait permettre de ne plus en oublier.